### PR TITLE
fix function syntax for zsh

### DIFF
--- a/colored-man-pages.plugin.zsh
+++ b/colored-man-pages.plugin.zsh
@@ -10,7 +10,7 @@
 # us       start underline
 # ue       stop underline
 
-man() {
+function man() {
 	env \
 		LESS_TERMCAP_mb=$(printf "\e[1;34m") \
 		LESS_TERMCAP_md=$(printf "\e[1;34m") \


### PR DESCRIPTION
Add `function` keyword to function definition to fix:
```
./colored-man-pages.plugin.zsh:13: defining function based on alias `man'
./colored-man-pages.plugin.zsh:13: parse error near `()'
```